### PR TITLE
fix: multiple function plot

### DIFF
--- a/src/recipes/funcplot.jl
+++ b/src/recipes/funcplot.jl
@@ -12,6 +12,7 @@ Interactively plot a function over a time range on a grid position
 """
 function functionplot(gp, f, tmin, tmax; axis = (;), add_title = DEFAULTS.add_title, add_colorbar = DEFAULTS.add_colorbar, plot = (;), kwargs...)
     # get a sample data to determine the attributes and plot types
+    tmin, tmax = _compat(tmin), _compat(tmax)
     data = f(tmin, tmax)
     m = @something meta(f) Dict()
     attrs = axis_attributes(f, tmin, tmax; data, add_title)
@@ -21,6 +22,10 @@ function functionplot(gp, f, tmin, tmax; axis = (;), add_title = DEFAULTS.add_ti
     isspectrogram(data) && add_colorbar && Colorbar(gp[1, 2], p; label = clabel(data))
     return PanelAxesPlots(gp, AxisPlots(ax, p))
 end
+
+# Need to convert string to DateTime for ComputePipeline
+_compat(x::String) = DateTime(x)
+_compat(x) = x
 
 """
     functionplot!(ax, f, tmin, tmax; kwargs...)
@@ -37,11 +42,8 @@ end
 Specialized multiplot function for `functionplot`.
 Merge specs before plotting so as to cycle through them.
 """
-function multiplot!(ax::Axis, fs, tmin, tmax; plotfunc = plot2spec, plot = (;), kwargs...)
-    to_plotspec = trange -> mapreduce(vcat, fs) do f
-        attrs = plottype_attributes(meta(f))
-        x = transform(apply(f, trange...))
-        plotfunc(x; attrs..., plot...)
-    end
-    return iviz_api!(ax, to_plotspec, (tmin, tmax); kwargs...)
+function multiplot!(ax, fs, tmin, tmax; kwargs...)
+    tmin, tmax = _compat(tmin), _compat(tmax)
+    func = (t0, t1) -> transform.(apply.(fs, t0, t1))
+    return iviz_api!(ax, func, (tmin, tmax); kwargs...)
 end

--- a/src/recipes/multiplot.jl
+++ b/src/recipes/multiplot.jl
@@ -1,7 +1,7 @@
 # Like `series` in https://github.com/MakieOrg/Makie.jl/blob/master/Makie/src/basic_recipes/series.jl
 # Also handle spectrogram
 
-function multiplot!(ax::Axis, tas, args...; plottypes = (), kwargs...)
+function multiplot!(ax, tas, args...; plottypes = (), kwargs...)
     ptypes = _plottypes(plottypes)
     return map(enumerate(tas)) do (i, x)
         x′ = transform(x)
@@ -10,6 +10,8 @@ function multiplot!(ax::Axis, tas, args...; plottypes = (), kwargs...)
         pf(ax, x′; kwargs...)
     end
 end
+
+multiplot!(ax, c::Computed, args...; kwargs...) = multiplot!(ax, c[]; kwargs...)
 
 """
     multiplot(gp, tas::MultiPlottable, args...; axis=(;), kwargs...)

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -12,6 +12,12 @@
     end
 
     f, axes = @test_nowarn tplot(func, t0, t1)
+
+    @testset "MultiFunctionPlot" begin
+        f2 = (t0, t1) -> -func(t0, t1)
+        @test_nowarn tplot([func, f2], t0, t1)
+        @test_nowarn tplot([[func, f2]], t0, t1)
+    end
 end
 
 @testitem "MultiAxisPlot" begin


### PR DESCRIPTION
docs: improve documentation structure and API reference
- move utility functions into new makie.jl file
- Standardize `plottypes` parameter naming across
